### PR TITLE
chore(dependencies): move shelljs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "moment": "^2.18.1",
     "nodemon": "^1.11.0",
     "rxjs": "^5.4.1",
+    "shelljs": "^0.7.7",
     "typescript": "^2.3.2"
   },
   "devDependencies": {
@@ -59,7 +60,6 @@
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",
     "proxyquire": "^1.8.0",
-    "shelljs": "^0.7.7",
     "sinon": "^2.1.0",
     "tslint": "^5.1.0",
     "tslint-config-acamica": "^1.0.1",


### PR DESCRIPTION
La versión `0.0.12` está rota. No funciona porque tenemos como `devDependency` a `shelljs` entonces al instalar el paquete esa dependencia no se instala y el paquete rompe al correr.

Este PR corrige eso, dado que en la versión anterior agregamos el feature de eliminar los archivos de la carpeta `dist` al hacer build, pero al mismo tiempo introdujimos este bug.

Deberíamos publicar una nueva versión después de mergear este cambio