### PR TITLE
chore(types): remove useless dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/commands/tsns.js",
   "author": "Hernan Rajchert <hrajchert@gmail.com>",
   "repository": {
-      "type": "git",
-      "url":"https://github.com/acamica/tsns"
+    "type": "git",
+    "url": "https://github.com/acamica/tsns"
   },
   "license": "MIT",
   "files": [
@@ -39,8 +39,6 @@
     "watch:test": "mocha dist/**/*.test.js -w --colors --debug --growl"
   },
   "dependencies": {
-    "@types/commander": "^2.9.1",
-    "@types/moment": "^2.13.0",
     "commander": "^2.9.0",
     "moment": "^2.18.1",
     "nodemon": "^1.11.0",
@@ -49,6 +47,7 @@
   },
   "devDependencies": {
     "@types/chai": "^3.5.1",
+    "@types/commander": "^2.9.1",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.12",
     "@types/proxyquire": "^1.3.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,6 @@
   version "2.2.41"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.41.tgz#e27cf0817153eb9f2713b2d3f6c68f1e1c3ca608"
 
-"@types/moment@^2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"
-  dependencies:
-    moment "*"
-
 "@types/node@*", "@types/node@^7.0.12":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.12.tgz#ae5f67a19c15f752148004db07cbbb372e69efc9"
@@ -1136,7 +1130,7 @@ module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
-moment@*, moment@^2.18.1:
+moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 


### PR DESCRIPTION
Este PR elimina la dependencia `@types/moment` porque los tipos de `moment` ya vienen con su paquete. De hecho, cuando se instala, te tira un warning de que los tipos ya están en ese paquete