### PR TITLE
feat(init): added task init (moved from typescript-node-starter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsns",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "",
   "main": "dist/commands/tsns.js",
   "author": "Hernan Rajchert <hrajchert@gmail.com>",
@@ -19,7 +19,8 @@
   "bin": {
     "tsns": "dist/commands/tsns.js",
     "tsns-run": "dist/commands/tsns-run.js",
-    "tsns-build": "dist/commands/tsns-build.js"
+    "tsns-build": "dist/commands/tsns-build.js",
+    "tsns-init": "dist/commands/tsns-init.js"
   },
   "scripts": {
     "commitmsg": "validate-commit-msg",
@@ -27,7 +28,7 @@
     "lint:ts": "tslint --project tsconfig.json",
     "lint-and-fix:-ts": "tslint --project tsconfig.json --fix",
     "start": "node dist/index.js",
-    "build": "rm -Rf dist && tsc && chmod a+x dist/commands/tsns.js && chmod a+x dist/commands/tsns-run.js && chmod a+x dist/commands/tsns-build.js",
+    "build": "rm -Rf dist && tsc && chmod a+x dist/commands/tsns.js && chmod a+x dist/commands/tsns-run.js && chmod a+x dist/commands/tsns-build.js && chmod a+x dist/commands/tsns-init.js",
     "test": "mocha dist/**/*.test.js --debug --colors",
     "tdd": "run-p watch:*",
     "docker:build": "docker build -t ${npm_package_name}:${npm_package_version} .",

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -1,0 +1,66 @@
+import { join } from 'path';
+import {askDefault, close} from '../../utils/promise-readline';
+import {which, exec, rm} from 'shelljs';
+import { readProjectPackageJSON } from '../../utils/package-json';
+import { writeProjectPackageJSON } from '../../utils/package-json/write-package';
+import paths from '../../utils/paths';
+
+if (!which('git')) {
+    console.error('You need to have git installed :\'(');
+    process.exit(1);
+}
+
+export async function init () {
+    // Read package json and prompt for the project information
+    const [projectInfo, packageJSON] = await Promise.all([promptProjectInfo(), readProjectPackageJSON()]);
+
+    // Replace package json defaults
+    const newPackage = {
+        ...packageJSON,
+        version: '0.0.1',
+        description: '',
+        author: getGitAuthor(),
+        name: projectInfo.name,
+        license: projectInfo.license
+    };
+
+    // Remove post install
+    delete newPackage.scripts['postinstall'];
+
+    // Write the new package json back
+    await writeProjectPackageJSON(newPackage);
+
+    // Reset git and make first commit
+    resetGit(projectInfo.name);
+}
+
+// Prompt the user for the project information
+async function promptProjectInfo () {
+    const folderName = paths.project.split('/').pop();
+    const name = await askDefault(`Name [${folderName}]: `, folderName || '');
+    const license = await askDefault('License [MIT]: ', 'MIT');
+    close();
+    return {name, license};
+}
+
+// Get a string with the users git info, like "Hernan Rajchert <hrajchert@gmail.com>"
+function getGitAuthor () {
+    const {name, email} = getGitUserInfo();
+    return `${name} <${email}>`;
+}
+
+// Reads git user info
+function getGitUserInfo () {
+    const name = exec('git config user.name', {silent: true}).stdout.toString().trim();
+    const email = exec('git config user.email', {silent: true}).stdout.toString().trim();
+    return {name, email};
+}
+
+function resetGit (projectName: string) {
+    // Delete current git
+    rm('-rf', join(paths.project, '.git'));
+    // Initialize git with a new first commit
+    exec(`git init "${paths.project}"`);
+    exec('git add .');
+    exec(`git commit -m "chore(general): Initialize ${projectName}"`);
+}

--- a/src/commands/tsns-init.ts
+++ b/src/commands/tsns-init.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import * as program from 'commander';
+import { tsnsVersion$ } from '../utils/package-json';
+import { init } from './init/init';
+
+tsnsVersion$
+    // Configure the program options
+    .map(version =>
+        program
+            .version(version)
+            .description('Inits the project (to be runned after instalation)')
+            .parse(process.argv)
+    )
+    // Build and Run the program
+    .switchMap(_ => init())
+    // .do(process => pipeOutput(process))
+    // .switchMap(process => closeWithErrorWhenStatusCode(process.close$))
+    .subscribe(
+        () => {},
+        err => {
+            console.error('There was an error running the program:', err);
+            process.exit(1);
+        }
+    );

--- a/src/commands/tsns.ts
+++ b/src/commands/tsns.ts
@@ -1,20 +1,13 @@
 #!/usr/bin/env node
 import * as program from 'commander';
-import {IPackageJson} from '../package.json';
-import {resolve, join} from 'path';
+import { readTsnsPackageJSON } from '../utils/package-json';
 
-import {readJSON} from '../utils/promise-fs';
-
-const root = resolve(__dirname, '../../');
-
-// Function to read the project package json
-const readPackageJSON = () => readJSON<IPackageJson>(join(root, 'package.json'));
-
-readPackageJSON()
+readTsnsPackageJSON()
     .then(packageJson =>
         program
             .command('run', 'Builds and run the project')
             .command('build', 'Builds the typescript project')
+            .command('init', 'Inits the project (to be runned after npm install)')
             .version(packageJson.version)
             .parse(process.argv)
     );

--- a/src/utils/package-json/get-package-path.ts
+++ b/src/utils/package-json/get-package-path.ts
@@ -1,0 +1,5 @@
+import { join } from 'path';
+import paths from '../paths';
+
+export const getTsnsPackageJSONPath = () => join(paths.tsnsRoot, 'package.json');
+export const getProjectPackageJSONPath = () => join(paths.project, 'package.json');

--- a/src/utils/package-json/get-version.ts
+++ b/src/utils/package-json/get-version.ts
@@ -1,21 +1,13 @@
 import {Observable} from 'rxjs';
-import {IPackageJson} from '../../package.json';
-import {join} from 'path';
-import paths from '../paths';
+import { readTsnsPackageJSON } from './read-package';
 
-import {readJSON} from '../promise-fs';
-
-
-// Function to read the project package json
-const readPackageJSON = (path: string) =>
+const readTsnsPackageJSON$ = () =>
                             Observable.fromPromise(
-                                readJSON<IPackageJson>(path)
+                                readTsnsPackageJSON()
                             );
 
 
-export const getVersionFromPackageJSON = (path: string) => readPackageJSON(path)
+const getVersionFromPackageJSON = () => readTsnsPackageJSON$()
                                                         .map(packageJson => packageJson.version);
 
-
-export const projectVersion$ = getVersionFromPackageJSON(join(paths.project, 'package.json'));
-export const tsnsVersion$ = getVersionFromPackageJSON(join(paths.tsnsRoot, 'package.json'));
+export const tsnsVersion$ = getVersionFromPackageJSON();

--- a/src/utils/package-json/index.ts
+++ b/src/utils/package-json/index.ts
@@ -1,1 +1,2 @@
 export * from './get-version';
+export * from './read-package';

--- a/src/utils/package-json/read-package.ts
+++ b/src/utils/package-json/read-package.ts
@@ -1,0 +1,6 @@
+import { readJSON } from '../promise-fs';
+import { IPackageJson } from '../index';
+import { getTsnsPackageJSONPath, getProjectPackageJSONPath } from './get-package-path';
+
+export const readTsnsPackageJSON = () => readJSON<IPackageJson>(getTsnsPackageJSONPath());
+export const readProjectPackageJSON = () => readJSON<IPackageJson>(getProjectPackageJSONPath());

--- a/src/utils/package-json/write-package.ts
+++ b/src/utils/package-json/write-package.ts
@@ -1,0 +1,5 @@
+import { getProjectPackageJSONPath } from './get-package-path';
+import { IPackageJson } from '../index';
+import { writeJSON } from '../promise-fs';
+
+export const writeProjectPackageJSON = (newPackage: IPackageJson) => writeJSON(getProjectPackageJSONPath(), newPackage);

--- a/src/utils/promise-fs.ts
+++ b/src/utils/promise-fs.ts
@@ -24,6 +24,11 @@ export const writeFile = (path: string, data: any) => new Promise<void>(
 
 export const readJSON = <T>(path: string) => readFile(path)
                                             .then(buffer => JSON.parse(buffer.toString()) as T);
+
+export const writeJSON = <T> (path: string, newPackage: T) =>
+    writeFile(path, JSON.stringify(newPackage, null, 2))
+;
+
 export const access = (path: string, options?: number) => new Promise<boolean>(
     resolve => {
         // If error resolve(false) else resolve(true)


### PR DESCRIPTION
# Description
* Adds `init` task (inits the project). Code copied from [typescript-node-starter](https://github.com/acamica/typescript-node-starter).
* Refactors previous code to avoid code duplication (specially code related to `package.json` readings).
* Tells apart `package.json`s from "_project_" (like clone of [typescript-node-starter](https://github.com/acamica/typescript-node-starter)) and "_tsns_" (this repo).